### PR TITLE
Update partman.cpp to upstream.

### DIFF
--- a/SpaceCadetPinball/partman.cpp
+++ b/SpaceCadetPinball/partman.cpp
@@ -6,129 +6,136 @@
 #include "zdrv.h"
 
 short partman::_field_size[] =
-{
-	2, -1, 2, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0
-};
+        {
+                2, -1, 2, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0
+        };
 
 DatFile* partman::load_records(LPCSTR lpFileName, bool fullTiltMode)
 {
-	datFileHeader header{};
-	dat8BitBmpHeader bmpHeader{};
-	dat16BitBmpHeader zMapHeader{};
+    datFileHeader header{};
+    dat8BitBmpHeader bmpHeader{};
+    dat16BitBmpHeader zMapHeader{};
 
-	auto fileHandle = fopen(lpFileName, "rb");
-	if (fileHandle == nullptr)
-		return nullptr;
+    auto fileHandle = fopen(lpFileName, "rb");
+    if (fileHandle == nullptr)
+        return nullptr;
 
-	fread(&header, 1, sizeof header, fileHandle);
-	if (strcmp("PARTOUT(4.0)RESOURCE", header.FileSignature) != 0)
-	{
-		fclose(fileHandle);
-		return nullptr;
-	}
+    fread(&header, 1, sizeof header, fileHandle);
+    if (strcmp("PARTOUT(4.0)RESOURCE", header.FileSignature) != 0)
+    {
+        fclose(fileHandle);
+        return nullptr;
+    }
 
-	auto datFile = new DatFile();
-	if (!datFile)
-	{
-		fclose(fileHandle);
-		return nullptr;
-	}
+    auto datFile = new DatFile();
+    if (!datFile)
+    {
+        fclose(fileHandle);
+        return nullptr;
+    }
 
-	datFile->AppName = header.AppName;
-	datFile->Description = header.Description;
+    datFile->AppName = header.AppName;
+    datFile->Description = header.Description;
 
-	if (header.Unknown)
-	{
-		auto unknownBuf = new char[header.Unknown];
-		if (!unknownBuf)
-		{
-			fclose(fileHandle);
-			delete datFile;
-			return nullptr;
-		}
-		fread(unknownBuf, 1, header.Unknown, fileHandle);
-		delete[] unknownBuf;
-	}
+    if (header.Unknown)
+    {
+        auto unknownBuf = new char[header.Unknown];
+        if (!unknownBuf)
+        {
+            fclose(fileHandle);
+            delete datFile;
+            return nullptr;
+        }
+        fread(unknownBuf, 1, header.Unknown, fileHandle);
+        delete[] unknownBuf;
+    }
 
-	datFile->Groups.reserve(header.NumberOfGroups);
-	bool abort = false;
-	for (auto groupIndex = 0; !abort && groupIndex < header.NumberOfGroups; ++groupIndex)
-	{
-		auto entryCount = LRead<uint8_t>(fileHandle);
-		auto groupData = new GroupData(groupIndex);
-		groupData->ReserveEntries(entryCount);
+    datFile->Groups.reserve(header.NumberOfGroups);
+    bool abort = false;
+    for (auto groupIndex = 0; !abort && groupIndex < header.NumberOfGroups; ++groupIndex)
+    {
+        auto entryCount = LRead<uint8_t>(fileHandle);
+        auto groupData = new GroupData(groupIndex);
+        groupData->ReserveEntries(entryCount);
 
-		for (auto entryIndex = 0; entryIndex < entryCount; ++entryIndex)
-		{
-			auto entryData = new EntryData();
-			auto entryType = static_cast<FieldTypes>(LRead<uint8_t>(fileHandle));
-			entryData->EntryType = entryType;
+        for (auto entryIndex = 0; entryIndex < entryCount; ++entryIndex)
+        {
+            auto entryData = new EntryData();
+            auto entryType = static_cast<FieldTypes>(LRead<uint8_t>(fileHandle));
+            entryData->EntryType = entryType;
 
-			int fixedSize = _field_size[static_cast<int>(entryType)];
-			size_t fieldSize = fixedSize >= 0 ? fixedSize : LRead<uint32_t>(fileHandle);
-			entryData->FieldSize = static_cast<int>(fieldSize);
+            int fixedSize = _field_size[static_cast<int>(entryType)];
+            size_t fieldSize = fixedSize >= 0 ? fixedSize : LRead<uint32_t>(fileHandle);
+            entryData->FieldSize = static_cast<int>(fieldSize);
 
-			if (entryType == FieldTypes::Bitmap8bit)
-			{
-				fread(&bmpHeader, 1, sizeof(dat8BitBmpHeader), fileHandle);
-				assertm(bmpHeader.Size + sizeof(dat8BitBmpHeader) == fieldSize, "partman: Wrong bitmap field size");
-				assertm(bmpHeader.Resolution <= 2, "partman: bitmap resolution out of bounds");
+            if (entryType == FieldTypes::Bitmap8bit)
+            {
+                fread(&bmpHeader, 1, sizeof(dat8BitBmpHeader), fileHandle);
+                assertm(bmpHeader.Size + sizeof(dat8BitBmpHeader) == fieldSize, "partman: Wrong bitmap field size");
+                assertm(bmpHeader.Resolution <= 2, "partman: bitmap resolution out of bounds");
 
-				auto bmp = new gdrv_bitmap8(bmpHeader);
-				entryData->Buffer = reinterpret_cast<char*>(bmp);
-				fread(bmp->IndexedBmpPtr, 1, bmpHeader.Size, fileHandle);
-			}
-			else if (entryType == FieldTypes::Bitmap16bit)
-			{
-				/*Full tilt has extra byte(@0:resolution) in zMap*/
-				auto zMapResolution = 0u;
-				if (fullTiltMode)
-				{
-					zMapResolution = LRead<uint8_t>(fileHandle);
-					fieldSize--;
-					assertm(zMapResolution <= 2, "partman: zMap resolution out of bounds");
-				}
+                auto bmp = new gdrv_bitmap8(bmpHeader);
+                entryData->Buffer = reinterpret_cast<char*>(bmp);
+                fread(bmp->IndexedBmpPtr, 1, bmpHeader.Size, fileHandle);
+            }
+            else if (entryType == FieldTypes::Bitmap16bit)
+            {
+                /*Full tilt has extra byte(@0:resolution) in zMap*/
+                auto zMapResolution = 0u;
+                if (fullTiltMode)
+                {
+                    zMapResolution = LRead<uint8_t>(fileHandle);
+                    fieldSize--;
 
-				fread(&zMapHeader, 1, sizeof(dat16BitBmpHeader), fileHandle);
-				auto length = fieldSize - sizeof(dat16BitBmpHeader);
+                    // -1 means universal resolution, maybe. FT demo .006 is the only known user.
+                    if (zMapResolution == 0xff)
+                        zMapResolution = 0;
 
-				auto zMap = new zmap_header_type(zMapHeader.Width, zMapHeader.Height, zMapHeader.Stride);
-				zMap->Resolution = zMapResolution;
-				if (zMapHeader.Stride * zMapHeader.Height * 2u == length)
-				{
-					fread(zMap->ZPtr1, 1, length, fileHandle);
-				}
-				else
-				{
-					// 3DPB .dat has zeroed zMap headers, in groups 497 and 498, skip them.
-					fseek(fileHandle, static_cast<int>(length), SEEK_CUR);
-				}
-				entryData->Buffer = reinterpret_cast<char*>(zMap);
-			}
-			else
-			{
-				auto entryBuffer = new char[fieldSize];
-				entryData->Buffer = entryBuffer;
-				if (!entryBuffer)
-				{
-					abort = true;
-					break;
-				}
-				fread(entryBuffer, 1, fieldSize, fileHandle);
-			}
+                    assertm(zMapResolution <= 2, "partman: zMap resolution out of bounds");
+                }
 
-			groupData->AddEntry(entryData);
-		}
+                fread(&zMapHeader, 1, sizeof(dat16BitBmpHeader), fileHandle);
+                auto length = fieldSize - sizeof(dat16BitBmpHeader);
 
-		datFile->Groups.push_back(groupData);
-	}
+                zmap_header_type* zMap;
+                if (zMapHeader.Stride * zMapHeader.Height * 2u == length)
+                {
+                    zMap = new zmap_header_type(zMapHeader.Width, zMapHeader.Height, zMapHeader.Stride);
+                    zMap->Resolution = zMapResolution;
+                    fread(zMap->ZPtr1, 1, length, fileHandle);
+                }
+                else
+                {
+                    // 3DPB .dat has zeroed zMap headers, in groups 497 and 498, skip them.
+                    fseek(fileHandle, static_cast<int>(length), SEEK_CUR);
+                    zMap = new zmap_header_type(0, 0, 0);
+                }
+                entryData->Buffer = reinterpret_cast<char*>(zMap);
+            }
+            else
+            {
+                auto entryBuffer = new char[fieldSize];
+                entryData->Buffer = entryBuffer;
+                if (!entryBuffer)
+                {
+                    abort = true;
+                    break;
+                }
+                fread(entryBuffer, 1, fieldSize, fileHandle);
+            }
 
-	fclose(fileHandle);
-	if (datFile->Groups.size() == header.NumberOfGroups)
-	{
-		datFile->Finalize();
-		return datFile;
-	}
-	delete datFile;
-	return nullptr;
+            groupData->AddEntry(entryData);
+        }
+
+        datFile->Groups.push_back(groupData);
+    }
+
+    fclose(fileHandle);
+    if (datFile->Groups.size() == header.NumberOfGroups)
+    {
+        datFile->Finalize();
+        return datFile;
+    }
+    delete datFile;
+    return nullptr;
 }


### PR DESCRIPTION
Looking through issue reports because I was running into a similar issue when attempting to run pinball on the android emulator, when the same APK ran fine on my own device.

The reason why #70 got the "Not enough memory to run 3D Pinball" is because the `zmap_header_type` constructor function in `zdrv.cpp` is attempting to create a several-gigabyte large array. This causes the program to just put its hands up and execute memalloc_failiure() in winmain.cpp, which shuts everything down and displays the aforementioned error message. Not enough memory is misleading; while technically true, it occurs due to a bug, the program should never request that much memory otherwise. 

The call to zmap_header_type that causes it to blow up is here:
https://github.com/fexed/Pinball-on-Android/blob/495a7f6fda2cc5b2d602ab62d8bc67d87f3551e1/SpaceCadetPinball/partman.cpp#L95  
Due to the seemingly random values that it attempts to pass in, I think that it's attempting to pass in an uninitialized value. I spent some time trying to fix it, but it seems that someone else upstream also experience this issue and fixed it up there. This is a literal copy and paste from upstream. 
As for the random and sporadic occurrence of this issue, my hunch is that this is some sort of undefined behavior that depends on the CPU architecture that is executing the code, AKA the most fun type of issues to debug. 

Due to the nature of the failure, this might fix #70, #73, #71, and some other "instant crash" bug reports. I tested my fix in android emulator and on a Moto G power 2020. Want to see how some other hardware responds before I call it a done job.